### PR TITLE
Support for non-blocking send() and recv() calls.

### DIFF
--- a/TLSSocketWrapper.h
+++ b/TLSSocketWrapper.h
@@ -185,6 +185,8 @@ private:
     void tls_init(void);
     /* Frees memory */
     void tls_free(void);
+    /* Returns true if TLS context is allocated, false if freed */
+    bool is_tls_allocated();
 };
 
 #endif // _MBED_HTTPS_TLS_SOCKET_WRAPPER_H_


### PR DESCRIPTION
connect() and close() still internally sets underlying socket to blocking.
For non-blocking operation, socket::set_blocking(false) needs to be
called after establishing the connection.